### PR TITLE
Various corrections to CSV and Metadata

### DIFF
--- a/example.csv
+++ b/example.csv
@@ -1,2 +1,2 @@
-isbn,title,author
+ISBN-10,Book Title,Book Author
 "0470402377","Bricklin on Technology","Dan Bricklin"

--- a/example.csv-metadata.json
+++ b/example.csv-metadata.json
@@ -1,8 +1,5 @@
 {
-  "@context": {
-    "@vocab": "http://www.w3.org/ns/csvw#", 
-    "dc": "http://purl.org/dc/terms/"
-  }, 
+  "@context": "http://www.w3.org/ns/csvw", 
   "@type": "Table", 
   "url": "example.csv",
   "dc:creator": "Dan Bricklin", 
@@ -15,9 +12,8 @@
     "columns": [
       {
         "name": "isbn",
-        "title": "ISBN-10",
+        "titles": "ISBN-10",
         "datatype": "string",
-        "unique": true,
         "propertyUrl": "http://purl.org/dc/terms/identifier"
       },
       {


### PR DESCRIPTION
Use "titles" to reference the column headings in CSV.
Use long title names in CSV.
Remove "unique", as it's implied by "primaryKey".
Fixes #2 
